### PR TITLE
Allow specifying the earliest revision in either position.

### DIFF
--- a/bin/run-command-on-git-revisions
+++ b/bin/run-command-on-git-revisions
@@ -41,13 +41,7 @@ run_tests() {
     # try it backwards if this was empty
     # this allows using either "master some_old_tag" or "some_old_tag master"
     if [ -z "$revs" ]; then
-        revs=`log_command git rev-list --reverse ${end_ref}..${start_ref}`
-        # if this worked, change our end_ref and start_ref pointers
-        if [ -n "$revs" ]; then
-            tmp=$start_ref
-            start_ref=$end_ref
-            end_ref=$tmp
-        fi
+        revs=`log_command git rev-list ${end_ref}..${start_ref}`
     fi
 
     for rev in $revs; do


### PR DESCRIPTION
This causes `run-command-on-git-revisions master $some_old_tag $cmd` to work as if
executed as `run-command-on-git-revisions $some_old_tag master $cmd`
