### PR TITLE
Now <leader> . works correctly with helper_spec

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -274,7 +274,7 @@ function! AlternateForCurrentFile()
   let new_file = current_file
   let in_spec = match(current_file, '^spec/') != -1
   let going_to_spec = !in_spec
-  let in_app = match(current_file, '\<controllers\>') != -1 || match(current_file, '\<models\>') != -1 || match(current_file, '\<views\>') != -1
+  let in_app = match(current_file, '\<controllers\>') != -1 || match(current_file, '\<models\>') != -1 || match(current_file, '\<views\>') || match(current_file, '\<helpers\>') != -1
   if going_to_spec
     if in_app
       let new_file = substitute(new_file, '^app/', '', '')


### PR DESCRIPTION
Hey, I have been using your .vimrc for sometime now, I discovered yesterday that without this modification when switching between helpers specs(using <leader> .). It would actually look for them in spec/app/helpers/ instead of spec/helpers/, now it works as intended. 
