### PR TITLE
Support running specs in legacy projects

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -328,6 +328,14 @@ function! SetTestFile()
     let t:grb_test_file=@%
 endfunction
 
+" Support running specs in legacy projects
+function! RSpecCommand()
+    let rspec_gem_path = system("bundle show rspec")
+    let rspec_command  = match(rspec_gem_path, "rspec-1") != -1 ? "spec" : "rspec"
+
+    return rspec_command
+endfunction
+
 function! RunTests(filename)
     " Write the file and run tests for the given filename
     :w
@@ -343,9 +351,9 @@ function! RunTests(filename)
         if filereadable("script/test")
             exec ":!script/test " . a:filename
         elseif filereadable("Gemfile")
-            exec ":!bundle exec rspec --color " . a:filename
+            exec ":!bundle exec " . RSpecCommand() . " --color " . a:filename
         else
-            exec ":!rspec --color " . a:filename
+            exec ":!" . RSpecCommand() . " --color " . a:filename
         end
     end
 endfunction


### PR DESCRIPTION
I'm not sure if you'll find this useful. It basically decides on whether to use 'rspec' or 'spec' to run tests depending on which version of RSpec you've specified in bundler.

It does mean running 'bundle show' every time you run tests, but this seems relatively quick.

This is my first attempt at vim scripting, so there are probably things that could be done better.

Cheers
