### PR TITLE
Avoids "Unmatched ) or \)" error

### DIFF
--- a/.githelpers
+++ b/.githelpers
@@ -29,9 +29,9 @@ show_git_head() {
 pretty_git_log() {
     git log --graph --pretty="tformat:${FORMAT}" $* |
         # Replace (2 years ago) with (2 years)
-        sed -Ee 's/(^[^<]*) ago)/\1)/' |
+        sed -Ee 's/(^[^<]*) ago\)/\1)/' |
         # Replace (2 years, 5 months) with (2 years)
-        sed -Ee 's/(^[^<]*), [[:digit:]]+ .*months?)/\1)/' |
+        sed -Ee 's/(^[^<]*), [[:digit:]]+ .*months?\)/\1)/' |
         # Line columns up based on } delimiter
         column -s '}' -t |
         # Page only if we need to


### PR DESCRIPTION
- GNU sed 4.2.1 on Ubuntu Precise raises an error unless the paren is escaped.
