### PR TITLE
Uses `.` instead of `source` to bring in ~/.githelpers

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -37,10 +37,10 @@
     #   la = all commits, all reachable refs
     head = !git l -1
     h = !git head
-    hp = "!source ~/.githelpers && show_git_head"
+    hp = "!. ~/.githelpers && show_git_head"
     r = !git l -30
     ra = !git r --all
-    l = "!source ~/.githelpers && pretty_git_log"
+    l = "!. ~/.githelpers && pretty_git_log"
     la = !git l --all
 
 [merge]


### PR DESCRIPTION
:warning: This pull request comes from [alindeman/dotfiles-1](http://github.com/alindeman/dotfiles-1), not [alindeman/dotfiles](http://github.com/alindeman/dotfiles) 
- Fixes #10
