### PR TITLE
Reduce .vimrc timeoutlen to 250

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -56,6 +56,8 @@ set wildmode=longest,list
 " make tab completion for files/buffers act like bash
 set wildmenu
 let mapleader=","
+" punish slow fingers, fix O lag
+set timeoutlen=250
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " CUSTOM AUTOCMDS


### PR DESCRIPTION
Reduces the timeout to 250 ms in order to mitigate frequent hangs on O line insertion. Has the side effect of punishing slow fingers when running leader commands. Makes VIM feel "snappier" which I suspect is entirely in my head but it does promote hair growth, increased energy, and a pink aura.
http://stackoverflow.com/questions/2158516/vim-delay-before-o-opens-a-new-line
