### PR TITLE
Update .vimrc to fix slow O inserts(key code timeout)

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -56,6 +56,9 @@ set wildmode=longest,list
 " make tab completion for files/buffers act like bash
 set wildmenu
 let mapleader=","
+" Fix slow O inserts
+:set timeout timeoutlen=1000 ttimeoutlen=100
+
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " CUSTOM AUTOCMDS


### PR DESCRIPTION
from :help ttimeoutlen

> The time in milliseconds that is waited for a key code or mapped key sequence to complete.  Also used for CTRL-\ CTRL-N and CTRL-\ CTRL-G when part of a command has been typed. Normally only 'timeoutlen' is used and 'ttimeoutlen' is -1.  When a different timeout value for key codes is desired set 'ttimeoutlen' to a non-negative number.

```
    ttimeoutlen mapping delay      key code delay
       < 0     'timeoutlen'       'timeoutlen'
      >= 0     'timeoutlen'       'ttimeoutlen'
```

> The timeout only happens when the 'timeout' and 'ttimeout' optio
>  tell so.  A useful setting would be

                :set timeout timeoutlen=3000 ttimeoutlen=100                                                                    

> (time out on mapping after three seconds, time out on key codes after
>     a tenth of a second).
