### PR TITLE
run-command-on-git-revisions aborts if run on a dirty repo

### DIFF
--- a/bin/run-command-on-git-revisions
+++ b/bin/run-command-on-git-revisions
@@ -29,13 +29,13 @@ main() {
 
 abort_if_dirty_repo() {
     set +e
-    staged_not_committed=$(git diff-index --quiet --cached HEAD)
-    if [[ $staged_not_committed -ne 0 ]]; then
+    git diff-index --quiet --cached HEAD
+    if [[ $? -ne 0 ]]; then
         echo "You have staged but not committed changes that would be lost! Aborting."
         exit 1
     fi
-    not_staged_not_committed=$(git diff-files --quiet)
-    if [[ $not_staged_not_committed -ne 0 ]]; then
+    git diff-files --quiet
+    if [[ $? -ne 0 ]]; then
         echo "You have unstaged changes that would be lost! Aborting."
         exit 1
     fi


### PR DESCRIPTION
It would not be nice to run the run-command-on-git-revisions on a dirty repo. I added a check with some hints from [stackoverflow](http://stackoverflow.com/a/2659808). The script now aborts if you have staged or unstaged changes or even untracked files.

Maybe I could add a --force flag to run anyway?
