### PR TITLE
Fix `less` not auto-exiting on long lines.

### DIFF
--- a/.githelpers
+++ b/.githelpers
@@ -56,6 +56,28 @@ pretty_git_log() {
         # Color merge commits specially
         sed -Ee "s/(Merge branch .* into .*$)/$(printf $ANSI_RED)\1$(printf $ANSI_RESET)/" |
         # Page only if we need to
-        less -FXRS
+        nowrap less -FXR
+}
+
+# Prevents terminal from wrapping text.
+#
+# `less --quit-if-one-screen --chop-long-lines` (`less -FS`) lets you scroll
+# horizontally to view longer-than-terminal-width lines, but it does not
+# automatically quit.
+#
+# `nowrap` unsets DECAWM[1] which tells terminal to draw excessive characters
+# on top of a right-most terminal column; runs command; sets DECAWM back.
+#
+# Better solution would be to use `tput rmam`[2] command, but tmux does not
+# respect it and has no other option to control wrapping[3].
+#
+# [1]: http://www.vt100.net/docs/vt510-rm/DECAWM
+# [2]: https://www.gnu.org/software/termutils/manual/termutils-2.0/html_chapter/tput_1.html#SEC8
+# [3]: http://sourceforge.net/p/tmux/tickets/14/
+nowrap() {
+    [ -t 1 ] && printf "\033[?7l"
+    "$@"; local ret="$?"
+    [ -t 1 ] && printf "\033[?7h"
+    return "$ret"
 }
 


### PR DESCRIPTION
I noticed that `less -FS` won't exit when encountering very long lines, even if output is shorter than screen height, which forces me to check if I need to press `q` after running `git r` and `git ra`.

I wrote `nowrap` function to always be sure that I can start typing next terminal command right away. It has an unfortunate side effect of altering very last character on the line due to the nature of how it works, but other than that it seems to be doing it's job perfectly.

Tested only in iTerm and regular Terminal (zsh and bash) on OS X, but it should work in any DEC VT100 emulating terminal, which is pretty much everything available today.

```
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.9.2
BuildVersion:   13C64
$ cat ~/Applications/iTerm.app/Contents/Info.plist | egrep -A1 CFBundleVersion
        <key>CFBundleVersion</key>
        <string>1.0.0.20140421</string>
$ zsh --version
zsh 5.0.5 (x86_64-apple-darwin13.0.0)
$ bash --version
GNU bash, version 3.2.51(1)-release (x86_64-apple-darwin13)
Copyright (C) 2007 Free Software Foundation, Inc.
$ tmux -V
tmux 1.9a
```
