### PR TITLE
Update .tmux.conf to avoid breaking tmux for Linux and bash users.

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -9,4 +9,4 @@ set -g history-limit 10000
 #
 # $ brew install reattach-to-user-namespace --wrap-pbcopy-and-pbpaste
 # This will only be run on Mac OS X.
-if-shell 'test `uname` == "Darwin"' 'set-option -g default-command "reattach-to-user-namespace -l zsh"'
+if-shell 'test `uname` == "Darwin"' 'set-option -g default-command "reattach-to-user-namespace -l `echo $SHELL`"'


### PR DESCRIPTION
.tmux.conf includes a copy/paste fix for vim running inside tmux. It works perfectly on Mac OS X, but breaks tmux on Linux (i.e. it won't even start on Ubuntu). This change makes tmux only run the command if on a Mac, to make the dotfiles more portable.
