### PR TITLE
Move numerical sort earlier in the pipeline

### DIFF
--- a/bin/git-churn
+++ b/bin/git-churn
@@ -18,6 +18,6 @@
 # (These are all standard arguments to `git log`.)
 
 set -e
-git log --all -M -C --name-only --format='format:' "$@" | sort | grep -v '^$' | uniq -c | sort | awk 'BEGIN {print "count\tfile"} {print $1 "\t" $2}' | sort -g
+git log --all -M -C --name-only --format='format:' "$@" | sort | grep -v '^$' | uniq -c | sort -n | awk 'BEGIN {print "count\tfile"} {print $1 "\t" $2}'
 
 


### PR DESCRIPTION
Correcting the previous patch, which added numerical sort at the end of the pipeline in stead of modifying the existing sort. Furthermore, `-n` is substituted for `-g`, since we are [dealing with integers](http://stackoverflow.com/questions/1255782/whats-the-difference-between-general-numeric-sort-and-numeric-sort-options).
