### PR TITLE
Don't generate unnecessary output in run-command-on-git-revisions

### DIFF
--- a/bin/run-command-on-git-revisions
+++ b/bin/run-command-on-git-revisions
@@ -65,7 +65,7 @@ run_tests() {
         debug "Checking out: $(git log --oneline -1 $rev)"
         log_command git checkout --quiet $rev
         log_command $test_command
-        log_command git reset --hard
+        log_command git reset --hard --quiet
     done
     log_command git checkout --quiet $end_ref
     debug "OK for all revisions!"


### PR DESCRIPTION
When doing the `reset --hard` it would output something like "HEAD is
now at as2zv22" which would interfer with other scripts. This was fixed
by adding `--quiet`.
