### PR TITLE
fix bug: when no test_command, exit code was 0

### DIFF
--- a/bin/run-command-on-git-revisions
+++ b/bin/run-command-on-git-revisions
@@ -12,6 +12,8 @@
 
 set -e
 
+E_BADARGS=85
+
 if [[ $1 == -v ]]; then
     verbose=1
     shift


### PR DESCRIPTION
Because E_BADARGS was an undeclared variable which defaults to 0.

E_BADARGS's value was taken from here: http://tldp.org/LDP/abs/html/wrapper.html