### PR TITLE
prevent double line number on running test files

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -332,7 +332,7 @@ function! RunTestFile(...)
     elseif !exists("t:grb_test_file")
         return
     end
-    call RunTests(t:grb_test_file . command_suffix)
+    call RunTests(t:grb_test_file)
 endfunction
 
 function! RunNearestTest()


### PR DESCRIPTION
hi gary

as of c28665324bcefb5a8477a9be6fbb1f573a2ec110, when running a specific
test via line number, you'd be running `spec/models/user_spec.rb:18:18`
(note the double line number). This was just a simple double append of
the line number.

Easy fix. Whilst rspec does actually handle double line numbers, other test runners don't handle it so well.