### PR TITLE
Alternate Workers Files

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -288,7 +288,7 @@ function! AlternateForCurrentFile()
   let new_file = current_file
   let in_spec = match(current_file, '^spec/') != -1
   let going_to_spec = !in_spec
-  let in_app = match(current_file, '\<controllers\>') != -1 || match(current_file, '\<models\>') != -1 || match(current_file, '\<views\>') != -1 || match(current_file, '\<helpers\>') != -1
+  let in_app = match(current_file, '\<controllers\>') != -1 || match(current_file, '\<models\>') != -1 || match(current_file, '\<workers\>') != -1 || match(current_file, '\<views\>') != -1 || match(current_file, '\<helpers\>') != -1
   if going_to_spec
     if in_app
       let new_file = substitute(new_file, '^app/', '', '')


### PR DESCRIPTION
In my recent projects I've a app/workers folder and the AlternateForCurrentFile function wasn't alternating properly for workers files. 

This PR fixes that function to properly alternate worker files.
