### PR TITLE
Restore buffers and alternate-file after RenameFile

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -186,7 +186,10 @@ function! RenameFile()
     let old_name = expand('%')
     let new_name = input('New file name: ', expand('%'), 'file')
     if new_name != '' && new_name != old_name
+        let old_alt = expand('#')
         exec ':saveas ' . new_name
+        let @# = old_alt
+        exec ':bd ' . bufnr(old_name)
         exec ':silent !rm ' . old_name
         redraw!
     endif


### PR DESCRIPTION
I'm a frequent user of alternate-file and the `RenameFile()` function, and after many-many times being frustrated by the dangling buffer after using `RenameFile()`, it turns out the solution is relatively simple and I have yet to find a situation where it will do the wrong thing and delete data.

Figured others might find it useful as well.