### PR TITLE
pretty print for git branch

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -17,7 +17,6 @@
     noff = merge --no-ff
     fa = fetch --all
     pom = push origin master
-    b = branch
     ds = diff --stat=160,120
     dh1 = diff HEAD~1
 
@@ -35,6 +34,8 @@
     #   ra = recent commits, all reachable refs
     #   l = all commits, only current branch
     #   la = all commits, all reachable refs
+    #   b = all branches
+    #   bs = all branches, sorted by last commit date
     head = !git r -1
     h = !git head
     hp = "!. ~/.githelpers && show_git_head"
@@ -42,6 +43,8 @@
     ra = !git r --all
     l = "!. ~/.githelpers && pretty_git_log"
     la = !git l --all
+    b = "!. ~/.githelpers && pretty_git_branch"
+    bs = "!. ~/.githelpers && pretty_git_branch_sorted"
 
 [merge]
     tool = vimdiff

--- a/.githelpers
+++ b/.githelpers
@@ -26,12 +26,13 @@ LOG_SUBJECT="%s"
 LOG_FORMAT="$LOG_HASH}$LOG_RELATIVE_TIME}$LOG_AUTHOR}$LOG_REFS $LOG_SUBJECT"
 
 BRANCH_PREFIX="%(HEAD)"
-BRANCH_NAME="%(color:yellow)%(refname:short)%(color:reset)"
+BRANCH_REF="%(color:red)%(color:bold)%(refname:short)%(color:reset)"
+BRANCH_HASH="%(color:yellow)%(objectname:short)%(color:reset)"
 BRANCH_DATE="%(color:green)(%(committerdate:relative))%(color:reset)"
 BRANCH_AUTHOR="%(color:blue)%(color:bold)<%(authorname)>%(color:reset)"
 BRANCH_CONTENTS="%(contents:subject)"
 
-BRANCH_FORMAT="$BRANCH_PREFIX}$BRANCH_NAME}$BRANCH_DATE}$BRANCH_AUTHOR}$BRANCH_CONTENTS"
+BRANCH_FORMAT="$BRANCH_PREFIX}$BRANCH_REF}$BRANCH_HASH}$BRANCH_DATE}$BRANCH_AUTHOR}$BRANCH_CONTENTS"
 
 ANSI_BLACK='\033[30m'
 ANSI_BLACK_BOLD='\033[0;30;1m'
@@ -62,11 +63,11 @@ pretty_git_log() {
 }
 
 pretty_git_branch() {
-    git for-each-ref refs/heads/ --format=${BRANCH_FORMAT} $* | pretty_git_format
+    git branch -v --format=${BRANCH_FORMAT} $* | pretty_git_format
 }
 
 pretty_git_branch_sorted() {
-    git for-each-ref --sort=-committerdate refs/heads/ --format=${BRANCH_FORMAT} $* | pretty_git_format
+    git branch -v --format=${BRANCH_FORMAT} --sort=-committerdate $* | pretty_git_format
 }
 
 pretty_git_format() {

--- a/.githelpers
+++ b/.githelpers
@@ -4,6 +4,10 @@
 #
 # * 51c333e    (12 days)    <Gary Bernhardt>   add vim-eunuch
 #
+# Branch output:
+#
+# * release/v1.1    (13 days)    <Leyan Lo>   add pretty_git_branch
+#
 # The time massaging regexes start with ^[^<]* because that ensures that they
 # only operate before the first "<". That "<" will be the beginning of the
 # author name, ensuring that we don't destroy anything in the commit message
@@ -13,13 +17,21 @@
 # used to split on them. A } in the commit subject or any other field will
 # break this.
 
-HASH="%C(yellow)%h%Creset"
-RELATIVE_TIME="%Cgreen(%ar)%Creset"
-AUTHOR="%C(bold blue)<%an>%Creset"
-REFS="%C(bold red)%d%Creset"
-SUBJECT="%s"
+LOG_HASH="%C(yellow)%h%Creset"
+LOG_RELATIVE_TIME="%Cgreen(%ar)%Creset"
+LOG_AUTHOR="%C(bold blue)<%an>%Creset"
+LOG_REFS="%C(bold red)%d%Creset"
+LOG_SUBJECT="%s"
 
-FORMAT="$HASH}$RELATIVE_TIME}$AUTHOR}$REFS $SUBJECT"
+LOG_FORMAT="$LOG_HASH}$LOG_RELATIVE_TIME}$LOG_AUTHOR}$LOG_REFS $LOG_SUBJECT"
+
+BRANCH_PREFIX="%(HEAD)"
+BRANCH_NAME="%(color:yellow)%(refname:short)%(color:reset)"
+BRANCH_DATE="%(color:green)(%(committerdate:relative))%(color:reset)"
+BRANCH_AUTHOR="%(color:blue)%(color:bold)<%(authorname)>%(color:reset)"
+BRANCH_CONTENTS="%(contents:subject)"
+
+BRANCH_FORMAT="$BRANCH_PREFIX}$BRANCH_NAME}$BRANCH_DATE}$BRANCH_AUTHOR}$BRANCH_CONTENTS"
 
 ANSI_BLACK='\033[30m'
 ANSI_BLACK_BOLD='\033[0;30;1m'
@@ -46,21 +58,31 @@ show_git_head() {
 }
 
 pretty_git_log() {
-    git log --graph --pretty="tformat:${FORMAT}" $* |
-        # Replace (2 years ago) with (2 years)
-        sed -Ee 's/(^[^<]*) ago\)/\1)/' |
-        # Replace (2 years, 5 months) with (2 years)
-        sed -Ee 's/(^[^<]*), [[:digit:]]+ .*months?\)/\1)/' |
-        # Line columns up based on } delimiter
-        column -s '}' -t |
-        # Color merge commits specially
-        sed -Ee "s/(Merge (branch|remote-tracking branch|pull request) .*$)/$(printf $ANSI_RED)\1$(printf $ANSI_RESET)/" |
-        # Page only if we're asked to.
-        if [ -n "$GIT_NO_PAGER" ]; then
-            cat
-        else
-            # Page only if needed.
-            less --quit-if-one-screen --no-init --RAW-CONTROL-CHARS --chop-long-lines
-        fi
+    git log --graph --pretty="tformat:${LOG_FORMAT}" $* | pretty_git_format
 }
 
+pretty_git_branch() {
+    git for-each-ref refs/heads/ --format=${BRANCH_FORMAT} $* | pretty_git_format
+}
+
+pretty_git_branch_sorted() {
+    git for-each-ref --sort=-committerdate refs/heads/ --format=${BRANCH_FORMAT} $* | pretty_git_format
+}
+
+pretty_git_format() {
+    # Replace (2 years ago) with (2 years)
+    sed -Ee 's/(^[^<]*) ago\)/\1)/' |
+    # Replace (2 years, 5 months) with (2 years)
+    sed -Ee 's/(^[^<]*), [[:digit:]]+ .*months?\)/\1)/' |
+    # Line columns up based on } delimiter
+    column -s '}' -t |
+    # Color merge commits specially
+    sed -Ee "s/(Merge (branch|remote-tracking branch|pull request) .*$)/$(printf $ANSI_RED)\1$(printf $ANSI_RESET)/" |
+    # Page only if we're asked to.
+    if [ -n "$GIT_NO_PAGER" ]; then
+        cat
+    else
+        # Page only if needed.
+        less --quit-if-one-screen --no-init --RAW-CONTROL-CHARS --chop-long-lines
+    fi
+}


### PR DESCRIPTION
First of all, thank you so much for your pretty git log. I use it all the time and share it as much as I can. I can't imagine using git without it.

In case you find this useful, I've modified your .githelpers to also do a fancy git branch. It's pretty much functionally equivalent to `git branch -v` or `git branch -v --sort=-committerdate`, but with colors that match the pretty log:
![screen shot 2017-09-26 at 10 25 26 pm](https://user-images.githubusercontent.com/1285326/30897341-8de9d878-a30a-11e7-8358-e23c79cd309a.png)
