### PR TITLE
Fixing printing of file paths that have spaces

### DIFF
--- a/bin/git-churn
+++ b/bin/git-churn
@@ -18,6 +18,5 @@
 # (These are all standard arguments to `git log`.)
 
 set -e
-git log --all -M -C --name-only --format='format:' "$@" | sort | grep -v '^$' | uniq -c | sort -n | awk 'BEGIN {print "count\tfile"} {print $1 "\t" $2}'
-
+git log --all -M -C --name-only --format='format:' "$@" | sort | grep -v '^$' | uniq -c | sort -n | awk  'BEGIN {print "count\tfile"} {printf $1 "\t" } {for(i=2;i<=NF;++i)printf $i} {print ""}'
 

--- a/bin/git-churn
+++ b/bin/git-churn
@@ -18,5 +18,4 @@
 # (These are all standard arguments to `git log`.)
 
 set -e
-git log --all -M -C --name-only --format='format:' "$@" | sort | grep -v '^$' | uniq -c | sort -n | awk  'BEGIN {print "count\tfile"} {printf $1 "\t" } {for(i=2;i<=NF;++i)printf $i} {print ""}'
-
+git log --all -M -C --name-only --format='format:' "$@" | sort | grep -v '^$' | uniq -c | sort -n | awk  'BEGIN{print"count\tfile"}{print$1"\t"substr($0,index($0,$2))}'


### PR DESCRIPTION
A file path with a space in it just printed to the first space - bit of a clunky fix in the awk code, but it works.