### PR TITLE
Do not show signature in pretty log

### DIFF
--- a/.githelpers
+++ b/.githelpers
@@ -40,7 +40,7 @@ show_git_head() {
 }
 
 pretty_git_log() {
-    git log --graph --pretty="tformat:${LOG_FORMAT}" $* | pretty_git_format | git_page_maybe
+    git log --graph --pretty="tformat:${LOG_FORMAT}" --no-show-signature $* | pretty_git_format | git_page_maybe
 }
 
 pretty_git_branch() {


### PR DESCRIPTION
When `git config log.ShowSignature true` is set, the signature will break the formatting for the pretty log.