### PR TITLE
Always use color for sorted branches

### DIFF
--- a/.githelpers
+++ b/.githelpers
@@ -48,7 +48,7 @@ pretty_git_branch() {
 }
 
 pretty_git_branch_sorted() {
-    git branch -v --format=${BRANCH_FORMAT} --sort=-committerdate $* | pretty_git_format
+    git branch -v --color=always --format=${BRANCH_FORMAT} --sort=-committerdate $* | pretty_git_format
 }
 
 pretty_git_format() {


### PR DESCRIPTION
Another trivial thing I noticed. Without this, colors are only used with "git b", not with "git bs".