### PR TITLE
Improve TabLine in grb256.vim

### DIFF
--- a/.vim/colors/grb256.vim
+++ b/.vim/colors/grb256.vim
@@ -9,6 +9,9 @@ hi Comment ctermfg=lightgrey
 
 hi StatusLine ctermbg=darkgrey ctermfg=white
 hi StatusLineNC ctermbg=black ctermfg=lightgrey
+hi TabLine ctermfg=lightgray ctermbg=NONE
+hi TabLineFill ctermbg=NONE ctermfg=NONE cterm=NONE
+hi TabLineSel ctermfg=white ctermbg=NONE cterm=bold
 hi VertSplit ctermbg=black ctermfg=lightgrey
 hi LineNr ctermfg=darkgray
 hi CursorLine       guifg=NONE        guibg=#121212     gui=NONE      ctermfg=NONE       ctermbg=234    cterm=NONE


### PR DESCRIPTION
Another man's vim files can be a very personal thing so a preemptive apology if I'm ironing the underwear. This change gets rid of the distracting Tab bgcolors and bolds the selected tab's text.

**Before:**

![vim0](https://user-images.githubusercontent.com/2344456/141409166-dd17ca7e-7e23-4395-8b0c-15bd31ddc733.png)

<hr />

**After:**

![vim1](https://user-images.githubusercontent.com/2344456/141409191-a5990699-6df9-49ef-97dd-a4fd3a96a0d8.png)
